### PR TITLE
Fix typo. Recurse more. Keep file times.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ Clone this repository and run the following:
 ```sh
 npm install
 
-node craft-to-obisidan your-folder-path
+node craft-to-obsidian your-folder-path
 ```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> This repository is no longer maintained.
+> You may want to get a more updated version on [the fork]([url](https://github.com/coofdy/craft-to-obsidian/tree/main)) by @coofdy
+
+
 # Craft to Obsidian
 
 Craft allows you to export notes in Markdown format, but you may not want to move them to Obsidian immediately due to certain differences. This repository contains a script that can help you migrate Craft notes to Obsidian by performing various tasks.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-> [!WARNING]
-> This repository is no longer maintained.
-> You may want to get a more updated version on [the fork]([url](https://github.com/coofdy/craft-to-obsidian/tree/main)) by @coofdy
-
-
 # Craft to Obsidian
 
 Craft allows you to export notes in Markdown format, but you may not want to move them to Obsidian immediately due to certain differences. This repository contains a script that can help you migrate Craft notes to Obsidian by performing various tasks.

--- a/craft-to-obsidian.js
+++ b/craft-to-obsidian.js
@@ -64,6 +64,9 @@ function removeTitle(folderPath) {
 
           if (lines.length > 0 && lines[0].trim().startsWith("# ")) {
             lines.shift(); // Remove the first line
+            if (lines.length > 0 && lines[0].trim().length == 0) {
+              lines.shift(); // Remove the following blank line
+            }
 
             fileContent = lines.join("\n");
 

--- a/craft-to-obsidian.js
+++ b/craft-to-obsidian.js
@@ -4,6 +4,12 @@ const fs = require("fs");
 const path = require("path");
 const Jimp = require("jimp");
 
+function writeFilesKeepingTimestamps(filePath, fileContent) {
+  let stat = fs.statSync(filePath)
+  fs.writeFileSync(filePath, fileContent);
+  fs.utimesSync(filePath, stat.atime, stat.mtime);
+}
+
 function renameFiles(folderPath) {
   const regex = /^(\d{4})\.(\d{2})\.(\d{2})\.md$/; // Regular expression to match "yyyy.mm.dd.md" format
 
@@ -70,7 +76,7 @@ function removeTitle(folderPath) {
 
             fileContent = lines.join("\n");
 
-            fs.writeFileSync(filePath, fileContent);
+            writeFilesKeepingTimestamps(filePath, fileContent);
             console.log(`Title removed from file ${fileName}`);
           } else {
             console.log(`No title found in file ${fileName}`);
@@ -97,7 +103,7 @@ function replaceAssetFolder(folderPath) {
         const updatedContent = fileContent.replace(regex, "($1-$2-$3.assets/");
 
         if (fileContent !== updatedContent) {
-          fs.writeFileSync(filePath, updatedContent);
+          writeFilesKeepingTimestamps(filePath, updatedContent);
           console.log(`Asset folder replaced in file ${filename}`);
         } else {
           console.log(`No asset folder found in file ${filename}`);
@@ -189,7 +195,7 @@ function replaceTiffWithPng(folderPath) {
         });
 
         if (fileContent !== updatedContent) {
-          fs.writeFileSync(filePath, updatedContent);
+          writeFilesKeepingTimestamps(filePath, updatedContent);
           console.log(
             `Replaced .tiff or .tif extensions with .png in file ${filename}`
           );
@@ -226,7 +232,7 @@ function replaceDailyNoteLink(folderPath) {
         content = content.replace(regex, replacement);
 
         // Write the modified content back to the file
-        fs.writeFileSync(filePath, content);
+        writeFilesKeepingTimestamps(filePath, content);
       }
     }
   });

--- a/craft-to-obsidian.js
+++ b/craft-to-obsidian.js
@@ -62,7 +62,7 @@ function removeTitle(folderPath) {
           let fileContent = fs.readFileSync(filePath, "utf-8");
           const lines = fileContent.split("\n");
 
-          if (lines.length > 0 && lines[0].trim().startsWith("#")) {
+          if (lines.length > 0 && lines[0].trim().startsWith("# ")) {
             lines.shift(); // Remove the first line
 
             fileContent = lines.join("\n");

--- a/craft-to-obsidian.js
+++ b/craft-to-obsidian.js
@@ -52,21 +52,26 @@ function removeTitle(folderPath) {
     const files = fs.readdirSync(folderPath);
 
     files.forEach((fileName) => {
-      if (fileName.endsWith(".md")) {
-        const filePath = path.join(folderPath, fileName);
+      const filePath = path.join(folderPath, fileName);
+      const isDirectory = fs.statSync(filePath).isDirectory();
 
-        let fileContent = fs.readFileSync(filePath, "utf-8");
-        const lines = fileContent.split("\n");
+      if (isDirectory) {
+        removeTitle(filePath);
+      } else {
+        if (fileName.endsWith(".md")) {
+          let fileContent = fs.readFileSync(filePath, "utf-8");
+          const lines = fileContent.split("\n");
 
-        if (lines.length > 0 && lines[0].trim().startsWith("#")) {
-          lines.shift(); // Remove the first line
+          if (lines.length > 0 && lines[0].trim().startsWith("#")) {
+            lines.shift(); // Remove the first line
 
-          fileContent = lines.join("\n");
+            fileContent = lines.join("\n");
 
-          fs.writeFileSync(filePath, fileContent);
-          console.log(`Title removed from file ${fileName}`);
-        } else {
-          console.log(`No title found in file ${fileName}`);
+            fs.writeFileSync(filePath, fileContent);
+            console.log(`Title removed from file ${fileName}`);
+          } else {
+            console.log(`No title found in file ${fileName}`);
+          }
         }
       }
     });
@@ -199,19 +204,28 @@ function replaceDailyNoteLink(folderPath) {
   // Read all files in the specified folder
   const files = fs.readdirSync(folderPath);
 
-  files.forEach((file) => {
-    const filePath = path.join(folderPath, file);
+  files.forEach((fileName) => {
+    const filePath = path.join(folderPath, fileName);
+    const isDirectory = fs.statSync(filePath).isDirectory();
 
-    // Read file content
-    let content = fs.readFileSync(filePath, "utf8");
+    if (isDirectory) {
+      replaceDailyNoteLink(filePath);
+    } else {
+      if (fileName.endsWith(".md")) {
+        const filePath = path.join(folderPath, fileName);
 
-    // Match and replace the daily note link format
-    const regex = /\[(.+?)\]\(day:\/\/(\d{4})\.(\d{2})\.(\d{2})\)/g;
-    const replacement = "[[$2-$3-$4]]";
-    content = content.replace(regex, replacement);
+        // Read file content
+        let content = fs.readFileSync(filePath, "utf8");
 
-    // Write the modified content back to the file
-    fs.writeFileSync(filePath, content);
+        // Match and replace the daily note link format
+        const regex = /\[(.+?)\]\(day:\/\/(\d{4})\.(\d{2})\.(\d{2})\)/g;
+        const replacement = "[[$2-$3-$4]]";
+        content = content.replace(regex, replacement);
+
+        // Write the modified content back to the file
+        fs.writeFileSync(filePath, content);
+      }
+    }
   });
 }
 


### PR DESCRIPTION
Thanks for making this useful tool.

I ended up adding these changes, which I think would be useful for anyone using craft-to-obsidian:

- Fix the typo in the example command-line that stops it working.
- Only touch heading 1 (# ), rather than any level heading.
- Remove the blank line that's left at the top of the document by the removal of the heading.
- Recursively perform all the changes over the entire folder structure.
- Keep the same files time-stamps as the exported documents had.